### PR TITLE
feat: Switch to dirhtml builder

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -25,11 +25,11 @@ jobs:
       env:
         SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        pipenv run make html
+        pipenv run make dirhtml
     - name: "store output"
       uses: "actions/upload-artifact@v3"
       with:
         name: "docs-html"
-        path: "build/html/"
+        path: "build/dirhtml/"
         retention-days: 1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,11 +35,11 @@ jobs:
       uses: "actions/download-artifact@v3"
       with:
         name: "docs-html"
-        path: "build/html"
+        path: "build/dirhtml"
     - name: "artifact / repackage"
       uses: "actions/upload-pages-artifact@v1"
       with:
-        path: "build/html"
+        path: "build/dirhtml"
     - name: "deploy / pages"
       id: "deployment"
       uses: "actions/deploy-pages@v2"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -36,7 +36,7 @@ jobs:
         workflow: "${{ github.event.workflow_run.workflow_id }}"
         run_id: "${{ github.event.workflow_run.id }}"
         name: "docs-html"
-        path: "build/html"
+        path: "build/dirhtml"
     - name: "generate data blob"
       id: "data"
       uses: "actions/github-script@v6"
@@ -44,7 +44,7 @@ jobs:
         script: |
           let fs = require("fs/promises");
 
-          let dirPromise = fs.mkdir('build/html/', {recursive: true});
+          let dirPromise = fs.mkdir('build/dirhtml/', {recursive: true});
           let prNum = (await fs.readFile('pr-num.txt', {encoding: 'UTF-8'})).trim();
           let time = new Date().toISOString();
 
@@ -62,7 +62,7 @@ jobs:
       uses: "JamesIves/github-pages-deploy-action@v4.4.2"
       with:
         branch: "main"
-        folder: "build/html"
+        folder: "build/dirhtml"
         ssh-key: "${{ secrets.SITE_PREVIEW_DEPLOY_KEY }}"
         repository-name: "Vineflower/vineflower-site-previews"
         target-folder: "pull/${{ fromJSON(steps.data.outputs.result).pr }}"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check: Makefile
 	@$(RSTCHECK) -r $(SOURCEDIR)
 
 livehtml: Makefile
-	sphinx-autobuild --re-ignore _build -b html "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS)
+	sphinx-autobuild --re-ignore _build -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)/dirhtml" $(SPHINXOPTS)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/make.bat
+++ b/make.bat
@@ -33,7 +33,7 @@ goto end
 goto end
 
 :livehtml
-sphinx-autobuild --re-ignore _build -b html %SOURCEDIR% %BUILDDIR%/html %SPHINXOPTS%
+sphinx-autobuild --re-ignore _build -b dirhtml %SOURCEDIR% %BUILDDIR%/dirhtml %SPHINXOPTS%
 goto end
 
 :end


### PR DESCRIPTION
This changes page paths from something like `vineflower.org/socials.html` to `vineflower.org/socials/`. This will break existing links to specific pages on the site, so without doing custom redirect glue it's a bit of a 'now-or-never' design decision.

As a result, in the source tree `socials.rst` and `socials/index.rst` become essentially equivalent.

This allows us to migrate single-page sections into multi-page sections over time without breaking existing links mostly -- easing growth of the documentation.

Thoughts?